### PR TITLE
Fire and forget api needs no reply

### DIFF
--- a/DBusMessage.cpp
+++ b/DBusMessage.cpp
@@ -1,0 +1,296 @@
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <cstring>
+
+#include <CommonAPI/Logger.hpp>
+#include <CommonAPI/DBus/DBusAddress.hpp>
+#include <CommonAPI/DBus/DBusMessage.hpp>
+
+namespace CommonAPI {
+namespace DBus {
+
+DBusMessage::DBusMessage()
+    : message_(NULL) {
+}
+
+DBusMessage::DBusMessage(::DBusMessage *_message) {
+    message_ = (_message != nullptr ? dbus_message_ref(_message) : nullptr);
+}
+
+DBusMessage::DBusMessage(::DBusMessage *_message, bool reference) {
+    if (NULL == _message) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " NULL _message");
+    }
+    message_ = (_message != nullptr ? (reference ? dbus_message_ref(message_) : _message) : nullptr);
+}
+
+DBusMessage::DBusMessage(const DBusMessage &_source) {
+    message_ = (_source.message_ != nullptr ?
+                    dbus_message_ref(_source.message_) : nullptr);
+}
+
+DBusMessage::DBusMessage(DBusMessage &&_source) {
+    message_ = _source.message_;
+    _source.message_ = nullptr;
+}
+
+DBusMessage::~DBusMessage() {
+    if (message_)
+        dbus_message_unref(message_);
+}
+
+DBusMessage &
+DBusMessage::operator=(const DBusMessage &_source) {
+    if (this != &_source) {
+        if (message_)
+            dbus_message_unref(message_);
+
+        message_ = (_source.message_ != nullptr ?
+                        dbus_message_ref(_source.message_) : nullptr);
+    }
+    return (*this);
+}
+
+DBusMessage &
+DBusMessage::operator=(DBusMessage &&_source) {
+    if (this != &_source) {
+        if (message_)
+            dbus_message_unref(message_);
+
+        message_ = _source.message_;
+        _source.message_ = NULL;
+    }
+    return (*this);
+}
+
+DBusMessage::operator bool() const {
+    return (nullptr != message_);
+}
+
+DBusMessage
+DBusMessage::createOrgFreedesktopOrgMethodCall(
+    const std::string &_method, const std::string &_signature) {
+
+    static DBusAddress address("org.freedesktop.DBus", "/", "org.freedesktop.DBus");
+    return DBusMessage::createMethodCall(address, _method, _signature);
+}
+
+DBusMessage
+DBusMessage::createMethodCall(
+    const DBusAddress &_address,
+    const std::string &_method, const std::string &_signature) {
+
+    std::string service = _address.getService();
+    std::string path = _address.getObjectPath();
+    std::string interface = _address.getInterface();
+
+    ::DBusMessage *methodCall = dbus_message_new_method_call(
+                                    service.c_str(), path.c_str(),
+                                    interface.c_str(), _method.c_str());
+    if (NULL == methodCall) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " dbus_message_new_method_call() returned NULL");
+    }
+
+    if ("" != _signature)
+        dbus_message_set_signature(methodCall, _signature.c_str());
+
+    return DBusMessage(methodCall, false);
+}
+
+DBusMessage
+DBusMessage::createMethodReturn(const std::string &_signature) const {
+    ::DBusMessage *methodReturn = dbus_message_new_method_return(message_);
+    if (NULL == methodReturn) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " dbus_message_new_method_return() returned NULL");
+    }
+
+    if ("" != _signature)
+       dbus_message_set_signature(methodReturn, _signature.c_str());
+
+    return DBusMessage(methodReturn, false);
+}
+
+DBusMessage
+DBusMessage::createMethodError(
+    const std::string &_code, const std::string &_signature, const std::string &_info) const {
+
+    ::DBusMessage *methodError
+          = dbus_message_new_error(message_, _code.c_str(), _info.c_str());
+    if (NULL == methodError) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " dbus_message_new_error() returned NULL");
+    }
+
+    dbus_message_set_signature(methodError, _signature.c_str());
+
+    return DBusMessage(methodError, false);
+}
+
+DBusMessage
+DBusMessage::createSignal(
+    const std::string &_path, const std::string &_interface,
+    const std::string &_signal, const std::string &_signature) {
+
+    ::DBusMessage *messageSignal
+          = dbus_message_new_signal(_path.c_str(), _interface.c_str(), _signal.c_str());
+    if (NULL == messageSignal) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " dbus_message_new_signal() returned NULL");
+    }
+
+    if ("" != _signature)
+        dbus_message_set_signature(messageSignal, _signature.c_str());
+
+    return DBusMessage(messageSignal, false);
+}
+
+const char *
+DBusMessage::getObjectPath() const {
+    return dbus_message_get_path(message_);
+}
+
+const char *
+DBusMessage::getSender() const {
+    return dbus_message_get_sender(message_);
+}
+
+const char *
+DBusMessage::getInterface() const {
+    return dbus_message_get_interface(message_);
+}
+
+const char *
+DBusMessage::getMember() const {
+    return dbus_message_get_member(message_);
+}
+
+const char *
+DBusMessage::getSignature() const {
+    return dbus_message_get_signature(message_);
+}
+
+const char *
+DBusMessage::getError() const {
+    if (!isErrorType()) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " !isErrorType");
+    }
+    return dbus_message_get_error_name(message_);
+}
+
+const char *
+DBusMessage::getDestination() const {
+    return dbus_message_get_destination(message_);
+}
+
+uint32_t DBusMessage::getSerial() const {
+    return dbus_message_get_serial(message_);
+}
+
+bool
+DBusMessage::hasObjectPath(const char *_path) const {
+    const char *path = getObjectPath();
+    if (NULL == _path) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " _path == NULL");
+    }
+    if (NULL == path) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " path == NULL");
+    }
+
+    return (((NULL != path) && (NULL != _path))? !strcmp(path, _path) : false);
+}
+
+bool DBusMessage::hasInterfaceName(const char *_interface) const {
+    const char *interface = getInterface();
+
+    if (NULL == _interface) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " _interface == NULL");
+    }
+    if (NULL == interface) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " interface == NULL");
+    }
+
+    return (((NULL != interface) && (NULL != _interface))? !strcmp(interface, _interface) : false);
+}
+
+bool DBusMessage::hasMemberName(const char *_member) const {
+    const char *member = getMember();
+
+    if (NULL == _member) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " _member == NULL");
+    }
+    if (NULL == member) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " member == NULL");
+    }
+
+    return (((NULL != member) && (NULL != _member))? !strcmp(member, _member) : false);
+}
+
+bool DBusMessage::hasSignature(const char *_signature) const {
+    const char *signature = getSignature();
+
+    if (NULL == _signature) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " _signature == NULL");
+    }
+    if (NULL == signature) {
+        COMMONAPI_ERROR(std::string(__FUNCTION__), " signature == NULL");
+    }
+
+    return (((NULL != signature) && (NULL != _signature))? !strcmp(signature, _signature) : false);
+}
+
+DBusMessage::Type DBusMessage::getType() const {
+    return static_cast<Type>(dbus_message_get_type(message_));
+}
+
+char * DBusMessage::getBodyData() const {
+    return dbus_message_get_body(message_);
+}
+
+int DBusMessage::getBodyLength() const {
+    return dbus_message_get_body_length(message_);
+}
+
+int DBusMessage::getBodySize() const {
+    return dbus_message_get_body_allocated(message_);
+}
+
+bool DBusMessage::setBodyLength(const int _length) {
+    return 0 != dbus_message_set_body_length(message_, _length);
+}
+
+bool DBusMessage::setDestination(const char *_destination)
+{
+    return 0 != dbus_message_set_destination(message_, _destination);
+}
+
+void DBusMessage::setSerial(const unsigned int _serial) const {
+    dbus_message_set_serial(message_, _serial);
+}
+
+bool DBusMessage::hasObjectPath(const std::string &_path) const {
+    return hasObjectPath(_path.c_str());
+}
+
+bool DBusMessage::isInvalidType() const {
+    return (getType() == Type::Invalid);
+}
+
+bool DBusMessage::isMethodCallType() const {
+    return (getType() == Type::MethodCall);
+}
+
+bool DBusMessage::isMethodReturnType() const {
+    return (getType() == Type::MethodReturn);
+}
+
+bool DBusMessage::isErrorType() const {
+    return (getType() == Type::Error);
+}
+
+bool DBusMessage::isSignalType() const {
+    return (getType() == Type::Signal);
+}
+
+} // namespace DBus
+} // namespace CommonAPI

--- a/DBusMessage.hpp
+++ b/DBusMessage.hpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#if !defined (COMMONAPI_INTERNAL_COMPILATION)
+#error "Only <CommonAPI/CommonAPI.hpp> can be included directly, this file may disappear or change contents."
+#endif
+
+#ifndef COMMONAPI_DBUS_DBUSMESSAGE_HPP_
+#define COMMONAPI_DBUS_DBUSMESSAGE_HPP_
+
+#include <string>
+
+#include <dbus/dbus.h>
+
+#ifdef _WIN32
+#include <stdint.h>
+#endif
+
+#include <CommonAPI/Export.hpp>
+
+namespace CommonAPI {
+namespace DBus {
+
+class DBusAddress;
+class DBusConnection;
+
+class COMMONAPI_EXPORT DBusMessage {
+public:
+    enum class Type: int {
+        Invalid = DBUS_MESSAGE_TYPE_INVALID,
+        MethodCall = DBUS_MESSAGE_TYPE_METHOD_CALL,
+        MethodReturn = DBUS_MESSAGE_TYPE_METHOD_RETURN,
+        Error = DBUS_MESSAGE_TYPE_ERROR,
+        Signal = DBUS_MESSAGE_TYPE_SIGNAL
+    };
+
+    DBusMessage();
+    DBusMessage(::DBusMessage* libdbusMessage);
+    DBusMessage(::DBusMessage* libdbusMessage, bool _reference);
+    DBusMessage(const DBusMessage &_source);
+    DBusMessage(DBusMessage &&_source);
+
+    ~DBusMessage();
+
+    DBusMessage &operator=(const DBusMessage &_source);
+    DBusMessage &operator=(DBusMessage &&_source);
+    operator bool() const;
+
+    static DBusMessage createOrgFreedesktopOrgMethodCall(const std::string &_method,
+                                                         const std::string &_signature = "");
+
+    static DBusMessage createMethodCall(const DBusAddress &_address,
+                                        const std::string &_method, const std::string &_signature = "");
+
+    DBusMessage createMethodReturn(const std::string &_signature) const;
+
+    DBusMessage createMethodError(const std::string &_name, const std::string &_signature = "s", const std::string &_reason = "") const;
+
+    static DBusMessage createSignal(const std::string& objectPath,
+                                    const std::string& interfaceName,
+                                    const std::string& signalName,
+                                    const std::string& signature = "");
+
+    const char* getSender() const;
+    const char* getObjectPath() const;
+    const char* getInterface() const;
+    const char* getMember() const;
+    const char* getSignature() const;
+    const char* getError() const;
+    const char* getDestination() const;
+    uint32_t getSerial() const;
+
+    bool hasObjectPath(const std::string& objectPath) const;
+
+    bool hasObjectPath(const char* objectPath) const;
+    bool hasInterfaceName(const char* interfaceName) const;
+    bool hasMemberName(const char* memberName) const;
+    bool hasSignature(const char* signature) const;
+
+    Type getType() const;
+    bool isInvalidType() const;
+    bool isMethodCallType() const;
+    bool isMethodReturnType() const;
+    bool isErrorType() const;
+    bool isSignalType() const;
+
+    char* getBodyData() const;
+    int getBodyLength() const;
+    int getBodySize() const;
+
+    bool setBodyLength(const int bodyLength);
+    bool setDestination(const char* destination);
+
+    void setSerial(const unsigned int serial) const;
+
+private:
+    ::DBusMessage *message_;
+
+    friend class DBusConnection;
+};
+
+} // namespace DBus
+} // namespace CommonAPI
+
+#endif // COMMONAPI_DBUS_DBUSMESSAGE_HPP_

--- a/DBusProxyHelper.hpp
+++ b/DBusProxyHelper.hpp
@@ -1,0 +1,510 @@
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#if !defined (COMMONAPI_INTERNAL_COMPILATION)
+#error "Only <CommonAPI/CommonAPI.hpp> can be included directly, this file may disappear or change contents."
+#endif
+
+#ifndef COMMONAPI_DBUS_DBUSPROXYHELPER_HPP_
+#define COMMONAPI_DBUS_DBUSPROXYHELPER_HPP_
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <string>
+
+#include <CommonAPI/DBus/DBusAddress.hpp>
+#include <CommonAPI/DBus/DBusConfig.hpp>
+#include <CommonAPI/DBus/DBusMessage.hpp>
+#include <CommonAPI/DBus/DBusSerializableArguments.hpp>
+#include <CommonAPI/DBus/DBusProxyAsyncCallbackHandler.hpp>
+#include <CommonAPI/DBus/DBusProxyConnection.hpp>
+#include <CommonAPI/DBus/DBusErrorEvent.hpp>
+
+namespace CommonAPI {
+namespace DBus {
+
+class DBusProxy;
+
+template< class, class... >
+struct DBusProxyHelper;
+
+#ifdef _WIN32
+// Visual Studio 2013 does not support 'magic statics' yet.
+// Change back when switched to Visual Studio 2015 or higher.
+static std::mutex callMethod_mutex_;
+static std::mutex callMethodWithReply_mutex_;
+static std::mutex callMethodAsync_mutex_;
+#endif
+
+template<
+    template<class ...> class In_, class... InArgs_,
+    template <class...> class Out_, class... OutArgs_>
+struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
+                           Out_<DBusInputStream, DBusOutputStream, OutArgs_...>> {
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethod(const DBusProxy_ &_proxy,
+                           const std::string &_method,
+                           const std::string &_signature,
+                           const InArgs_&... _in,
+                           CommonAPI::CallStatus &_status) {
+#ifndef _WIN32
+        static std::mutex callMethod_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethod_mutex_);
+
+        if (_proxy.isAvailable()) {
+            DBusMessage message = _proxy.createMethodCall(_method, _signature);
+            if (sizeof...(InArgs_) > 0) {
+                DBusOutputStream output(message);
+                if (!DBusSerializableArguments<InArgs_...>::serialize(output, _in...)) {
+                    _status = CallStatus::OUT_OF_MEMORY;
+                    return;
+                }
+                output.flush();
+            }
+
+            const bool isSent = _proxy.getDBusConnection()->sendDBusMessage(message);
+            _status = (isSent ? CallStatus::SUCCESS : CallStatus::OUT_OF_MEMORY);
+        } else {
+            _status = CallStatus::NOT_AVAILABLE;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                    const DBusProxy_ &_proxy,
+                    const DBusMessage &_message,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    CommonAPI::CallStatus &_status,
+                    OutArgs_&... _out) {
+
+        if (sizeof...(InArgs_) > 0) {
+            DBusOutputStream output(_message);
+            if (!DBusSerializableArguments<InArgs_...>::serialize(output, _in...)) {
+                _status = CallStatus::OUT_OF_MEMORY;
+                return;
+            }
+            output.flush();
+        }
+
+        DBusError error;
+        DBusMessage reply = _proxy.getDBusConnection()->sendDBusMessageWithReplyAndBlock(_message, error, _info);
+        if (error || !reply.isMethodReturnType()) {
+            _status = CallStatus::REMOTE_ERROR;
+            return;
+        }
+
+        if (sizeof...(OutArgs_) > 0) {
+            DBusInputStream input(reply);
+            if (!DBusSerializableArguments<OutArgs_...>::deserialize(input, _out...)) {
+                _status = CallStatus::REMOTE_ERROR;
+                return;
+            }
+        }
+        _status = CallStatus::SUCCESS;
+    }
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                const DBusProxy_ &_proxy,
+                const DBusAddress &_address,
+                const char *_method,
+                const char *_signature,
+                const CommonAPI::CallInfo *_info,
+                const InArgs_&... _in,
+                CommonAPI::CallStatus &_status,
+                OutArgs_&... _out) {
+#ifndef _WIN32
+        static std::mutex callMethodWithReply_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
+
+        if (_proxy.isAvailable()) {
+            DBusMessage message = DBusMessage::createMethodCall(_address, _method, _signature);
+            callMethodWithReply(_proxy, message, _info, _in..., _status, _out...);
+        } else {
+            _status = CallStatus::NOT_AVAILABLE;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                const DBusProxy_ &_proxy,
+                const std::string &_interface,
+                const std::string &_method,
+                const std::string &_signature,
+                const CommonAPI::CallInfo *_info,
+                const InArgs_&... _in,
+                CommonAPI::CallStatus &_status,
+                OutArgs_&... _out) {
+        DBusAddress itsAddress(_proxy.getDBusAddress());
+        itsAddress.setInterface(_interface);
+        callMethodWithReply(
+                _proxy, itsAddress,
+                _method.c_str(), _signature.c_str(),
+                _info,
+                _in..., _status, _out...);
+    }
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                    const DBusProxy_ &_proxy,
+                    const std::string &_method,
+                    const std::string &_signature,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    CommonAPI::CallStatus &_status,
+                    OutArgs_&... _out) {
+#ifndef _WIN32
+        static std::mutex callMethodWithReply_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
+
+        if (_proxy.isAvailable()) {
+            DBusMessage message = _proxy.createMethodCall(_method, _signature);
+            callMethodWithReply(_proxy, message, _info, _in..., _status, _out...);
+        } else {
+            _status = CallStatus::NOT_AVAILABLE;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                    DBusProxy_ &_proxy,
+                    const DBusMessage &_message,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    DelegateFunction_ _function,
+                    std::tuple<OutArgs_...> _out) {
+        if (sizeof...(InArgs_) > 0) {
+            DBusOutputStream output(_message);
+            const bool success = DBusSerializableArguments<
+                                    InArgs_...
+                                 >::serialize(output, _in...);
+            if (!success) {
+                std::promise<CallStatus> promise;
+                promise.set_value(CallStatus::OUT_OF_MEMORY);
+                return promise.get_future();
+            }
+            output.flush();
+        }
+
+        typename DBusProxyAsyncCallbackHandler<
+                                    DBusProxy, OutArgs_...
+                                >::Delegate delegate(_proxy.shared_from_this(), _function);
+        auto dbusMessageReplyAsyncHandler = std::move(DBusProxyAsyncCallbackHandler<
+                                                                DBusProxy, OutArgs_...
+                                                                >::create(delegate, _out));
+
+        std::future<CallStatus> callStatusFuture;
+        try {
+            callStatusFuture = dbusMessageReplyAsyncHandler->getFuture();
+        } catch (std::exception& e) {
+            COMMONAPI_ERROR("MethodAsync(dbus): messageReplyAsyncHandler future failed(", e.what(), ")");
+        }
+
+        if(_proxy.isAvailable()) {
+            if (_proxy.getDBusConnection()->sendDBusMessageWithReplyAsync(
+                            _message,
+                            std::move(dbusMessageReplyAsyncHandler),
+                            _info)){
+            COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy available -> sendMessageWithReplyAsync");
+                return callStatusFuture;
+            } else {
+            	return std::future<CallStatus>();
+            }
+        } else {
+            std::shared_ptr< std::unique_ptr< DBusProxyConnection::DBusMessageReplyAsyncHandler > > sharedDbusMessageReplyAsyncHandler(
+                    new std::unique_ptr< DBusProxyConnection::DBusMessageReplyAsyncHandler >(std::move(dbusMessageReplyAsyncHandler)));
+            //async isAvailable call with timeout
+            COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy not available -> register callback");
+            _proxy.isAvailableAsync([&_proxy, _message, sharedDbusMessageReplyAsyncHandler](
+                                             const AvailabilityStatus _status,
+                                             const Timeout_t remaining) {
+                if(_status == AvailabilityStatus::AVAILABLE) {
+                    //create new call info with remaining timeout. Minimal timeout is 100 ms.
+                    Timeout_t newTimeout = remaining;
+                    if(remaining < 100)
+                        newTimeout = 100;
+                    CallInfo newInfo(newTimeout);
+                    if(*sharedDbusMessageReplyAsyncHandler) {
+                    _proxy.getDBusConnection()->sendDBusMessageWithReplyAsync(
+                                    _message,
+                                    std::move(*sharedDbusMessageReplyAsyncHandler),
+                                    &newInfo);
+                    COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy callback available -> sendMessageWithReplyAsync");
+                    } else {
+                        COMMONAPI_ERROR("MethodAsync(dbus): Proxy callback available but callback taken");
+                    }
+                } else {
+                    //create error message and push it directly to the connection
+                    unsigned int dummySerial = 999;
+                    _message.setSerial(dummySerial);   //set dummy serial
+                    if (*sharedDbusMessageReplyAsyncHandler) {
+                        DBusMessage errorMessage = _message.createMethodError(DBUS_ERROR_UNKNOWN_METHOD);
+                        _proxy.getDBusConnection()->pushDBusMessageReplyToMainLoop(errorMessage,
+                        std::move(*sharedDbusMessageReplyAsyncHandler));
+                        COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy callback not reachable -> sendMessageWithReplyAsync");
+                    } else {
+                        COMMONAPI_ERROR("MethodAsync(dbus): Proxy callback not reachable but callback taken");
+                    }
+                }
+            }, _info);
+            return callStatusFuture;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                        DBusProxy_ &_proxy,
+                        const DBusAddress &_address,
+                        const std::string &_method,
+                        const std::string &_signature,
+                        const CommonAPI::CallInfo *_info,
+                        const InArgs_&... _in,
+                        DelegateFunction_ _function,
+                        std::tuple<OutArgs_...> _out) {
+#ifndef _WIN32
+        static std::mutex callMethodAsync_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);
+
+        DBusMessage message = DBusMessage::createMethodCall(_address, _method, _signature);
+        return callMethodAsync(_proxy, message, _info, _in..., _function, _out);
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                DBusProxy_ &_proxy,
+                const std::string &_interface,
+                const std::string &_method,
+                const std::string &_signature,
+                const CommonAPI::CallInfo *_info,
+                const InArgs_&... _in,
+                DelegateFunction_ _function,
+                std::tuple<OutArgs_...> _out) {
+        DBusAddress itsAddress(_proxy.getDBusAddress());
+        itsAddress.setInterface(_interface);
+        return callMethodAsync(
+                    _proxy, itsAddress,
+                    _method, _signature,
+                    _info,
+                    _in..., _function,
+                    _out);
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                    DBusProxy_ &_proxy,
+                    const std::string &_method,
+                    const std::string &_signature,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    DelegateFunction_ _function,
+                    std::tuple<OutArgs_...> _out) {
+#ifndef _WIN32
+        static std::mutex callMethodAsync_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);
+
+        DBusMessage message = _proxy.createMethodCall(_method, _signature);
+        return callMethodAsync(_proxy, message, _info, _in..., _function, _out);
+    }
+
+    template <int... ArgIndices_>
+    static void callCallbackOnNotAvailable(std::function<void(CallStatus, OutArgs_&...)> _callback,
+                                           index_sequence<ArgIndices_...>, std::tuple<OutArgs_...> _out) {
+        const CallStatus status(CallStatus::NOT_AVAILABLE);
+       _callback(status, std::get<ArgIndices_>(_out)...);
+       (void)_out;
+    }
+};
+
+template<
+    template <class ...> class In_, class... InArgs_,
+    template <class...> class Out_, class... OutArgs_,
+    class... ErrorEvents_>
+struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
+                           Out_<DBusInputStream, DBusOutputStream, OutArgs_...>,
+                           ErrorEvents_...> {
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                    const DBusProxy_ &_proxy,
+                    const DBusMessage &_message,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    CommonAPI::CallStatus &_status,
+                    OutArgs_&... _out,
+                    const std::tuple<ErrorEvents_*...> &_errorEvents) {
+
+        if (sizeof...(InArgs_) > 0) {
+            DBusOutputStream output(_message);
+            if (!DBusSerializableArguments<InArgs_...>::serialize(output, _in...)) {
+                _status = CallStatus::OUT_OF_MEMORY;
+                return;
+            }
+            output.flush();
+        }
+
+        DBusError error;
+        DBusMessage reply = _proxy.getDBusConnection()->sendDBusMessageWithReplyAndBlock(_message, error, _info);
+        if (error) {
+            DBusErrorEventHelper::notifyListeners(reply,
+                                                  error.getName(),
+                                                  typename make_sequence_range<sizeof...(ErrorEvents_), 0>::type(),
+                                                  _errorEvents);
+            _status = CallStatus::REMOTE_ERROR;
+            return;
+        }
+
+        if (sizeof...(OutArgs_) > 0) {
+            DBusInputStream input(reply);
+            if (!DBusSerializableArguments<OutArgs_...>::deserialize(input, _out...)) {
+                _status = CallStatus::REMOTE_ERROR;
+                return;
+            }
+        }
+        _status = CallStatus::SUCCESS;
+    }
+
+
+    template <typename DBusProxy_ = DBusProxy>
+    static void callMethodWithReply(
+                    const DBusProxy_ &_proxy,
+                    const std::string &_method,
+                    const std::string &_signature,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    CommonAPI::CallStatus &_status,
+                    OutArgs_&... _out,
+                    const std::tuple<ErrorEvents_*...> &_errorEvents){
+#ifndef _WIN32
+        static std::mutex callMethodWithReply_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
+
+        if (_proxy.isAvailable()) {
+            DBusMessage message = _proxy.createMethodCall(_method, _signature);
+            callMethodWithReply(_proxy, message, _info, _in..., _status, _out..., _errorEvents);
+        } else {
+            _status = CallStatus::NOT_AVAILABLE;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                    DBusProxy_ &_proxy,
+                    const DBusMessage &_message,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    DelegateFunction_ _function,
+                    std::tuple<OutArgs_...> _out,
+                    const std::tuple<ErrorEvents_*...> &_errorEvents) {
+        if (sizeof...(InArgs_) > 0) {
+            DBusOutputStream output(_message);
+            const bool success = DBusSerializableArguments<
+                                    InArgs_...
+                                 >::serialize(output, _in...);
+            if (!success) {
+                std::promise<CallStatus> promise;
+                promise.set_value(CallStatus::OUT_OF_MEMORY);
+                return promise.get_future();
+            }
+            output.flush();
+        }
+
+        typename DBusProxyAsyncCallbackHandler<DBusProxy, OutArgs_...>::Delegate delegate(
+                _proxy.shared_from_this(), _function);
+        auto dbusMessageReplyAsyncHandler = std::move(DBusProxyAsyncCallbackHandler<
+                                                      std::tuple<ErrorEvents_*...>,
+                                                      DBusProxy,
+                                                      OutArgs_...>::create(delegate, _out, _errorEvents));
+
+        std::future<CallStatus> callStatusFuture;
+        try {
+            callStatusFuture = dbusMessageReplyAsyncHandler->getFuture();
+        } catch (std::exception& e) {
+            COMMONAPI_ERROR("MethodAsync(dbus): messageReplyAsyncHandler future failed(", e.what(), ")");
+        }
+
+        if(_proxy.isAvailable()) {
+            if (_proxy.getDBusConnection()->sendDBusMessageWithReplyAsync(
+                            _message,
+                            std::move(dbusMessageReplyAsyncHandler),
+                            _info)){
+            COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy available -> sendMessageWithReplyAsync");
+                return callStatusFuture;
+            } else {
+                return std::future<CallStatus>();
+            }
+        } else {
+            std::shared_ptr< std::unique_ptr< DBusProxyConnection::DBusMessageReplyAsyncHandler > > sharedDbusMessageReplyAsyncHandler(
+                    new std::unique_ptr< DBusProxyConnection::DBusMessageReplyAsyncHandler >(std::move(dbusMessageReplyAsyncHandler)));
+            //async isAvailable call with timeout
+            COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy not available -> register callback");
+            _proxy.isAvailableAsync([&_proxy, _message, sharedDbusMessageReplyAsyncHandler](
+                                             const AvailabilityStatus _status,
+                                             const Timeout_t remaining) {
+                if(_status == AvailabilityStatus::AVAILABLE) {
+                    //create new call info with remaining timeout. Minimal timeout is 100 ms.
+                    Timeout_t newTimeout = remaining;
+                    if(remaining < 100)
+                        newTimeout = 100;
+                    CallInfo newInfo(newTimeout);
+                    if(*sharedDbusMessageReplyAsyncHandler) {
+                    _proxy.getDBusConnection()->sendDBusMessageWithReplyAsync(
+                                    _message,
+                                    std::move(*sharedDbusMessageReplyAsyncHandler),
+                                    &newInfo);
+                    COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy callback available -> sendMessageWithReplyAsync");
+                    } else {
+                        COMMONAPI_ERROR("MethodAsync(dbus): Proxy callback available but callback taken");
+                    }
+                } else {
+                    //create error message and push it directly to the connection
+                    unsigned int dummySerial = 999;
+                    _message.setSerial(dummySerial);   //set dummy serial
+                    if (*sharedDbusMessageReplyAsyncHandler) {
+                        DBusMessage errorMessage = _message.createMethodError(DBUS_ERROR_UNKNOWN_METHOD);
+                        _proxy.getDBusConnection()->pushDBusMessageReplyToMainLoop(errorMessage,
+                        std::move(*sharedDbusMessageReplyAsyncHandler));
+                        COMMONAPI_VERBOSE("MethodAsync(dbus): Proxy callback not reachable -> sendMessageWithReplyAsync");
+                    } else {
+                        COMMONAPI_ERROR("MethodAsync(dbus): Proxy callback not reachable but callback taken");
+                    }
+                }
+            }, _info);
+            return callStatusFuture;
+        }
+    }
+
+    template <typename DBusProxy_ = DBusProxy, typename DelegateFunction_>
+    static std::future<CallStatus> callMethodAsync(
+                    DBusProxy_ &_proxy,
+                    const std::string &_method,
+                    const std::string &_signature,
+                    const CommonAPI::CallInfo *_info,
+                    const InArgs_&... _in,
+                    DelegateFunction_ _function,
+                    std::tuple<OutArgs_...> _out,
+                    const std::tuple<ErrorEvents_*...> &_errorEvents) {
+#ifndef _WIN32
+        static std::mutex callMethodAsync_mutex_;
+#endif
+        std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);
+
+        DBusMessage message = _proxy.createMethodCall(_method, _signature);
+        return callMethodAsync(_proxy, message, _info, _in..., _function, _out, _errorEvents);
+    }
+};
+
+} // namespace DBus
+} // namespace CommonAPI
+
+#endif // COMMONAPI_DBUS_DBUSPROXYHELPER_HPP_

--- a/include/CommonAPI/DBus/DBusMessage.hpp
+++ b/include/CommonAPI/DBus/DBusMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -14,7 +14,7 @@
 
 #include <dbus/dbus.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdint.h>
 #endif
 
@@ -94,6 +94,7 @@ public:
     bool setDestination(const char* destination);
 
     void setSerial(const unsigned int serial) const;
+    void setNoReplyExpected(bool replyNotExpected);
 
 private:
     ::DBusMessage *message_;

--- a/include/CommonAPI/DBus/DBusProxyHelper.hpp
+++ b/include/CommonAPI/DBus/DBusProxyHelper.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -31,7 +31,7 @@ class DBusProxy;
 template< class, class... >
 struct DBusProxyHelper;
 
-#ifdef WIN32
+#ifdef _WIN32
 // Visual Studio 2013 does not support 'magic statics' yet.
 // Change back when switched to Visual Studio 2015 or higher.
 static std::mutex callMethod_mutex_;
@@ -51,13 +51,14 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                            const std::string &_signature,
                            const InArgs_&... _in,
                            CommonAPI::CallStatus &_status) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethod_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethod_mutex_);
 
         if (_proxy.isAvailable()) {
             DBusMessage message = _proxy.createMethodCall(_method, _signature);
+            message.setNoReplyExpected(TRUE);
             if (sizeof...(InArgs_) > 0) {
                 DBusOutputStream output(message);
                 if (!DBusSerializableArguments<InArgs_...>::serialize(output, _in...)) {
@@ -119,7 +120,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                 const InArgs_&... _in,
                 CommonAPI::CallStatus &_status,
                 OutArgs_&... _out) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodWithReply_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
@@ -160,7 +161,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     const InArgs_&... _in,
                     CommonAPI::CallStatus &_status,
                     OutArgs_&... _out) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodWithReply_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
@@ -269,7 +270,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                         const InArgs_&... _in,
                         DelegateFunction_ _function,
                         std::tuple<OutArgs_...> _out) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodAsync_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);
@@ -307,7 +308,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     const InArgs_&... _in,
                     DelegateFunction_ _function,
                     std::tuple<OutArgs_...> _out) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodAsync_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);
@@ -384,7 +385,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     CommonAPI::CallStatus &_status,
                     OutArgs_&... _out,
                     const std::tuple<ErrorEvents_*...> &_errorEvents){
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodWithReply_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodWithReply_mutex_);
@@ -494,7 +495,7 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     DelegateFunction_ _function,
                     std::tuple<OutArgs_...> _out,
                     const std::tuple<ErrorEvents_*...> &_errorEvents) {
-#ifndef WIN32
+#ifndef _WIN32
         static std::mutex callMethodAsync_mutex_;
 #endif
         std::lock_guard<std::mutex> lock(callMethodAsync_mutex_);

--- a/src/CommonAPI/DBus/DBusMessage.cpp
+++ b/src/CommonAPI/DBus/DBusMessage.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2015 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// Copyright (C) 2013-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -290,6 +290,10 @@ bool DBusMessage::isErrorType() const {
 
 bool DBusMessage::isSignalType() const {
     return (getType() == Type::Signal);
+}
+
+void DBusMessage::setNoReplyExpected(bool replyNotExpected) {
+    dbus_message_set_no_reply (message_, (0 != replyNotExpected) ? TRUE : FALSE);
 }
 
 } // namespace DBus


### PR DESCRIPTION
Max number of replies that can be pending for each connection count is limited to 127 and 50000 in case of SYSTEM bus and SESSION bus respectively. Currently when an api call of type fireAndForget is made, it's DBUS_HEADER_FLAG_NO_REPLY_EXPECTED flag is false so the count for pending call is incremented for every call of type fireAndForget and since no reply is sent for such calls this count will keep on increasing till it reaches the configuration specified limit. Once the limit is reached, no more calls can be made. Since fireAndForget api calls don't expect any reply/response we can set the flag DBUS_HEADER_FLAG_NO_REPLY_EXPECTED to FALSE.