### PR TITLE
Check if correct dbus library is found during cmake phase not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,21 @@ else()
 endif()
 
 ##############################################################################
+# Check for correct dbus version (with patches)
+
+try_compile(DBUS_WITH_PATCHES ${CMAKE_BINARY_DIR}/cmake_checks 
+    SOURCES ${CMAKE_SOURCE_DIR}/cmake/check_dbus_connection_send_with_reply_and_block.cpp
+    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${DBus_INCLUDE_DIRS}"
+    CMAKE_FLAGS "-DLINK_DIRECTORIES=${DBus_LIBRARY_DIRS}"
+    LINK_LIBRARIES ${DBus_LIBRARIES}
+    OUTPUT_VARIABLE dbus_out
+)
+
+if(NOT ${DBUS_WITH_PATCHES})
+    message(FATAL_ERROR "DBus library: ${DBus_LIBRARY_DIRS}/${DBus_LIBRARIES} is not patched")
+endif()
+
+##############################################################################
 
 # CommonAPI-DBus build section
 

--- a/cmake/check_dbus_connection_send_with_reply_and_block.cpp
+++ b/cmake/check_dbus_connection_send_with_reply_and_block.cpp
@@ -1,0 +1,8 @@
+
+#include <dbus/dbus.h>
+
+int main(void) {
+    auto z = dbus_connection_send_with_reply_set_notify(nullptr, nullptr, nullptr,
+                                                 nullptr, nullptr, nullptr, 0);
+    return 0;
+}


### PR DESCRIPTION
We can determine if correct DBus library (patched one) has been found
during CMake phase and give a nice error to the user rather than having
a compiler error.

This patch only checks if dbus_connection_send_with_reply_set_notify
function is present in dbus headers, but this can be easily extended to
check for all patches that are needed.