### PR TITLE
Extend DBusObjectManager to use GetAll

### DIFF
--- a/include/CommonAPI/DBus/DBusStubAdapter.hpp
+++ b/include/CommonAPI/DBus/DBusStubAdapter.hpp
@@ -16,6 +16,7 @@
 #include <CommonAPI/Stub.hpp>
 #include <CommonAPI/DBus/DBusAddress.hpp>
 #include <CommonAPI/DBus/DBusInterfaceHandler.hpp>
+#include <CommonAPI/DBus/DBusOutputStream.hpp>
 
 namespace CommonAPI {
 namespace DBus {
@@ -46,6 +47,8 @@ class COMMONAPI_EXPORT_CLASS_EXPLICIT DBusStubAdapter
      COMMONAPI_EXPORT virtual void deactivateManagedInstances() = 0;
      COMMONAPI_EXPORT virtual bool hasFreedesktopProperties();
      COMMONAPI_EXPORT virtual bool onInterfaceDBusFreedesktopPropertiesMessage(const DBusMessage &_message) = 0;
+
+     COMMONAPI_EXPORT virtual bool appendGetAllReply(const DBusMessage& dbusMessage, DBusOutputStream& dbusOutputStream) = 0;
 
  protected:
     DBusAddress dbusAddress_;

--- a/src/CommonAPI/DBus/DBusObjectManagerStub.cpp
+++ b/src/CommonAPI/DBus/DBusObjectManagerStub.cpp
@@ -307,43 +307,59 @@ bool DBusObjectManagerStub::onInterfaceDBusMessage(const DBusMessage& dbusMessag
     }
 
     std::lock_guard<std::mutex> dbusObjectManagerStubLock(dbusObjectManagerStubLock_);
-    DBusObjectPathAndInterfacesDict dbusObjectPathAndInterfacesDict;
 
-    for (const auto& registeredDBusObjectPathIterator : registeredDBusObjectPathsMap_) {
+    DBusMessage dbusMessageReply = dbusMessage.createMethodReturn("a{oa{sa{sv}}}");
+    DBusOutputStream dbusOutputStream(dbusMessageReply);
+	dbusOutputStream.beginWriteMap();
+
+    for (const auto& registeredDBusObjectPathIterator : registeredDBusObjectPathsMap_)
+    {
         const std::string& registeredDBusObjectPath = registeredDBusObjectPathIterator.first;
         const auto& registeredDBusInterfacesMap = registeredDBusObjectPathIterator.second;
-        DBusInterfacesAndPropertiesDict dbusInterfacesAndPropertiesDict;
 
         if (0 == registeredDBusObjectPath.length()) {
             COMMONAPI_ERROR(std::string(__FUNCTION__), " empty object path");
         } else {
+
             if (0 == registeredDBusInterfacesMap.size()) {
                 COMMONAPI_ERROR(std::string(__FUNCTION__), " empty interfaces map for ", registeredDBusObjectPath);
             }
 
-            for (const auto& registeredDBusInterfaceIterator : registeredDBusInterfacesMap) {
+            dbusOutputStream.align(8);
+            dbusOutputStream << registeredDBusObjectPath;
+            dbusOutputStream.beginWriteMap();
+
+            for (const auto& registeredDBusInterfaceIterator : registeredDBusInterfacesMap)
+            {
                 const std::string& registeredDBusInterfaceName = registeredDBusInterfaceIterator.first;
                 const auto& registeredDBusStubAdapter = registeredDBusInterfaceIterator.second.begin();
 
                 if (0 == registeredDBusInterfaceName.length()) {
                     COMMONAPI_ERROR(std::string(__FUNCTION__), " empty interface name for ", registeredDBusObjectPath);
                 } else {
-                    dbusInterfacesAndPropertiesDict.insert({ registeredDBusInterfaceName, DBusPropertiesChangedDict() });
+                    dbusOutputStream.align(8);
+                    dbusOutputStream << registeredDBusInterfaceName;
+                    dbusOutputStream.beginWriteMap();
+
+					(*registeredDBusStubAdapter)->appendGetAllReply(dbusMessage, dbusOutputStream);
+
+                    dbusOutputStream.endWriteMap();
                 }
 
-                if ((*registeredDBusStubAdapter)->isManaging()) {
-                    dbusInterfacesAndPropertiesDict.insert({ getInterfaceName(), DBusPropertiesChangedDict() });
+                if ((*registeredDBusStubAdapter)->isManaging())
+                {
+//                	dbusOutputStream.align(8);
+//                    dbusOutputStream << std::string(getInterfaceName());
+//                    dbusOutputStream << DBusPropertiesChangedDict();
+
                 }
             }
 
-            dbusObjectPathAndInterfacesDict.insert({ registeredDBusObjectPath, std::move(dbusInterfacesAndPropertiesDict) });
+            dbusOutputStream.endWriteMap();
         }
     }
 
-    DBusMessage dbusMessageReply = dbusMessage.createMethodReturn("a{oa{sa{sv}}}");
-    DBusOutputStream dbusOutputStream(dbusMessageReply);
-
-    dbusOutputStream << dbusObjectPathAndInterfacesDict;
+    dbusOutputStream.endWriteMap();
     dbusOutputStream.flush();
 
     const bool dbusMessageReplySent = dbusConnection->sendDBusMessage(dbusMessageReply);


### PR DESCRIPTION
The DBusObjectManager is specified by freedesktop to return as each
value in inner dict the same dict that would be returned by the
org.freedesktop.DBus.Properties.GetAll() method for that combination of
object path and interface. Only if an interface has no properties, an
empty dict will be returned.